### PR TITLE
Fixed AuthenticationListener for Symfony 2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/vendor/
+composer.lock

--- a/EventListener/AuthenticationListener.php
+++ b/EventListener/AuthenticationListener.php
@@ -43,7 +43,7 @@ class AuthenticationListener
      */
     public function onAuthenticationSuccess(AuthenticationEvent $e)
     {
-        $this->authentication->onAuthenticationSuccess($e->getToken());
+        $this->authentication->onAuthenticationSuccess($e->getAuthenticationToken());
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -264,7 +264,13 @@ gordalina_mixpanel:
             phone: phone
 ```
 
+Spec
+----
 
+In order to run the specs install all components with composer and run:
+```
+./bin/phpspec run
+```
 
 License
 -------

--- a/Security/UserData.php
+++ b/Security/UserData.php
@@ -88,6 +88,9 @@ class UserData
     public function getProperties($instance = null)
     {
         $instance = $this->getUser($instance);
+        if (empty($instance) || !is_object($instance)) {
+            return array();
+        }
         $className = get_class($instance);
 
         if (isset($this->properties[$className])) {

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,19 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "2.6.*",
         "mixpanel/mixpanel-php": "~2.6"
     },
-    "require-dev": {},
+    "require-dev": {
+        "phpspec/phpspec": "~2.1"
+    },
     "autoload": {
       "psr-0": { "Gordalina\\MixpanelBundle": "" }
     },
     "target-dir": "Gordalina/MixpanelBundle",
+    "config": {
+        "bin-dir": "bin"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.7-dev"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "2.6.*",
+        "symfony/framework-bundle": "~2.4",
         "mixpanel/mixpanel-php": "~2.6"
     },
     "require-dev": {

--- a/spec/Gordalina/MixpanelBundle/EventListener/AuthenticationListenerSpec.php
+++ b/spec/Gordalina/MixpanelBundle/EventListener/AuthenticationListenerSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\Gordalina\MixpanelBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class AuthenticationListenerSpec extends ObjectBehavior
+{
+    /**
+     * @param Symfony\Component\Security\Core\SecurityContextInterface $securityContext
+     * @param Gordalina\MixpanelBundle\Security\Authentication $authentication
+     */
+    function let($securityContext, $authentication)
+    {
+        $this->beConstructedWith($securityContext, $authentication);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Gordalina\MixpanelBundle\EventListener\AuthenticationListener');
+    }
+
+    /**
+     * @param Gordalina\MixpanelBundle\Security\Authentication $authentication
+     * @param Symfony\Component\Security\Core\Event\AuthenticationEvent $event
+     * @param Symfony\Component\Security\Core\Authentication\Token\TokenInterface $token
+     */
+    function it_should_pass_authentication_token_to_authentication_service($authentication, $event, $token)
+    {
+        $event->getAuthenticationToken()->willReturn($token);
+
+        $authentication->onAuthenticationSuccess($token)->shouldBeCalled();
+
+        $this->onAuthenticationSuccess($event);
+    }
+}

--- a/spec/Gordalina/MixpanelBundle/Security/UserDataSpec.php
+++ b/spec/Gordalina/MixpanelBundle/Security/UserDataSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace spec\Gordalina\MixpanelBundle\Security;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class UserDataSpec extends ObjectBehavior
+{
+    /**
+     * @param Symfony\Component\Security\Core\SecurityContextInterface $securityContext
+     * @param Gordalina\MixpanelBundle\ManagerRegistry $registry
+     */
+    function let($securityContext, $registry)
+    {
+        $this->beConstructedWith($securityContext, $registry);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Gordalina\MixpanelBundle\Security\UserData');
+    }
+
+    /**
+     * @param Symfony\Component\Security\Core\SecurityContextInterface $securityContext
+     * @param Symfony\Component\Security\Core\Authentication\Token\AnonymousToken $token
+     */
+    function it_should_return_empty_properties_when_user_is_anonymous($securityContext, $token)
+    {
+        $securityContext->getToken()->willReturn($token);
+
+        $token->getUser()->willReturn('anon.');
+
+        $this->getProperties()->shouldReturn(array());
+    }
+}


### PR DESCRIPTION
I've fixed the bundle so that it can be used with Symfony 2.6

There was an error with the `AuthenticationListener` since the `AuthenticationEvent` doesn't have the `getToken` method anymore - instead it has `getAuthenticationToken`

I've also added a simple spec for this class written in `PHPSpec`.
