### PR TITLE
Do not call updateDataAnnotation if the condition returns false

### DIFF
--- a/Mixpanel/EventListener/ControllerListener.php
+++ b/Mixpanel/EventListener/ControllerListener.php
@@ -113,7 +113,7 @@ class ControllerListener
         }
 
         if ($value instanceof Annotation\Expression) {
-            $element = $this->expressionLanguage->evaluate($value->expression, $request->attributes->all());
+            $element = $this->expressionLanguage->evaluate($value->expression, array_merge($request->attributes->all(), ['request' => $request]));
         }
 
         if (null === $element) {

--- a/Mixpanel/EventListener/ControllerListener.php
+++ b/Mixpanel/EventListener/ControllerListener.php
@@ -69,8 +69,9 @@ class ControllerListener
         foreach ([$classAnnotations, $methodAnnotations] as $collection) {
             foreach ($collection as $annotation) {
                 if ($annotation instanceof Annotation\Annotation) {
-                    $this->prepareAnnotation($annotation, $event->getRequest());
-                    if ($annotation->condition) {
+                    $this->handleCondition($annotation, $event->getRequest());
+                    if (true === $annotation->condition) {
+                        $this->prepareAnnotation($annotation, $event->getRequest());
                         $this->eventDispatcher->dispatch(new MixpanelEvent($annotation, $event->getRequest()));
                     }
                 }
@@ -92,21 +93,20 @@ class ControllerListener
         }
     }
 
+    private function handleCondition(Annotation\Annotation $annotation, Request $request)
+    {
+        $value = $annotation->condition;
+
+        if (null !== $value) {
+            $annotation->condition = $this->expressionLanguage->evaluate($value, array_merge(['request' => $request], $request->attributes->all()));
+        } else {
+            $annotation->condition = true;
+        }
+    }
+
     private function updateDataAnnotation(Annotation\Annotation $annotation, Request $request, string $key, $value, ?string $parentKey = null)
     {
         $element = null;
-
-        if ('condition' === $key) {
-            if (null === $value) {
-                $annotation->condition = true;
-
-                return;
-            }
-
-            $annotation->condition = $this->expressionLanguage->evaluate($value, array_merge(['request' => $request], $request->attributes->all()));
-
-            return;
-        }
 
         if ($value instanceof Annotation\Id) {
             $element = $this->userData->getId();


### PR DESCRIPTION
Let's say you have this controller with those condition placed on your Mixpanel annotations:

```php
    /**
     * @Route("/articles", name="article_index")
     * @Route("/articles/{category}", name="article_category_index")
     *
     * @Mixpanel\Track("List articles with category", condition="category !== null", props={
     *      "category": @Mixpanel\Expression("category.getSlug()")
     * }))
     * @Mixpanel\Track("List articles", condition="category === null")
     */
    public function indexAction(?Category $category = null): Response {
```

The code would crash because the `updateDataAnnotation` would be called even if the condition of the mixpanel annotation returns false;

So,

On a route: `/articles` category would be null (`$category = null`) but since the `updateDataAnnotation` calls the expressionLanguage for the `@Mixpanel\Expression("category.getSlug()"` part, the code crashes.

With this patch, the `updateDataAnnotation` is called **only** if the `condition` evaluates to true, or if the condition is `null` (= is missing).

So the `@Mixpanel\Expression("category.getSlug()")` is **not called** because the condition `condition="category !== null"` returns `false`


