### PR TITLE
fix: ensure `UserData::getProperties()` always return an array

### DIFF
--- a/Mixpanel/Security/UserData.php
+++ b/Mixpanel/Security/UserData.php
@@ -136,7 +136,7 @@ class UserData
 
             return $this->properties[$className];
         }
-        
+
         return [];
     }
 

--- a/Mixpanel/Security/UserData.php
+++ b/Mixpanel/Security/UserData.php
@@ -136,6 +136,8 @@ class UserData
 
             return $this->properties[$className];
         }
+        
+        return [];
     }
 
     /**


### PR DESCRIPTION
If there are no matching classes in the registry compared to the instance, it was returning null, which was incorrect according to the method signature.

This is related to #31. This solves the error that occurred because of the different in return value, but it does not solve the underlying issue which is the class comparison when using a doctrine proxy.