### PR TITLE
fix: registering flusher listener to be based on kernel.terminate

### DIFF
--- a/Mixpanel/EventListener/FinishRequestListener.php
+++ b/Mixpanel/EventListener/FinishRequestListener.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Gordalina\MixpanelBundle\Mixpanel\EventListener;
 
 use Gordalina\MixpanelBundle\Mixpanel\Mixpanel\Flusher;
-use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
-class FinishRequestListener
+class TerminateListener
 {
     /**
      * @var Flusher
@@ -28,7 +28,7 @@ class FinishRequestListener
         $this->flusher = $flusher;
     }
 
-    public function onFinishRequest(FinishRequestEvent $e)
+    public function onTerminate(TerminateEvent $e)
     {
         $this->flusher->flush();
     }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -28,9 +28,9 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.controller, method: onKernelController, priority: -256 }
 
-    Gordalina\MixpanelBundle\Mixpanel\EventListener\FinishRequestListener:
+    Gordalina\MixpanelBundle\Mixpanel\EventListener\TerminateListener:
         tags:
-            - { name: kernel.event_listener, event: kernel.finish_request, method: onFinishRequest, priority: -99 }
+            - { name: kernel.event_listener, event: kernel.terminate, method: onTerminate, priority: -99 }
 
     Gordalina\MixpanelBundle\Mixpanel\DataCollector\MixpanelDataCollector:
         tags:


### PR DESCRIPTION
Closes https://github.com/gordalina/GordalinaMixpanelBundle/issues/38